### PR TITLE
Fixed the image preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class App extends React.Component {
 | onChange | Function | - | On change handler for the input. |
 | buttonClassName | String | - | Class name for upload button. |
 | buttonStyles | Object | - | Inline styles for upload button. |
-| withPreview | Boolean | true | Show preview of selected images. |
+| withPreview | Boolean | false | Show preview of selected images. |
 | accept | String | "accept=image/*" | Accept attribute for file input. |
 | name | String | - | Input name. |
 | withIcon | Boolean | true | If true, show upload icon on top |

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -180,7 +180,7 @@ class ReactImageUploadComponent extends React.PureComponent {
 						accept={this.props.accept}
 						className={this.props.className}
 					/>
-					{this.renderPreview()}
+					{ this.props.withPreview ? this.renderPreview() : null }
 				</div>
 			</div>
 		)


### PR DESCRIPTION
Currently the image preview was always showing, even if passing false to the withPreview prop.
I added a check if the prop is set to true and updated the documentation with the correct default prop for withPreview.